### PR TITLE
Add logic to handle de-serializing new values that aren't supported yet

### DIFF
--- a/Manatee.Trello/Internal/DataAccess/JsonRepository.cs
+++ b/Manatee.Trello/Internal/DataAccess/JsonRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Manatee.Trello.Internal.RequestProcessing;
@@ -60,6 +61,11 @@ namespace Manatee.Trello.Internal.DataAccess
 				TrelloConfiguration.Log.Error(response.Exception);
 				if (TrelloConfiguration.ThrowOnTrelloError)
 				{
+					if (response.StatusCode != 0)
+					{
+						throw new HttpRequestException($"HTTP Error {response.StatusCode}", response.Exception);
+					}
+
 					throw response.Exception;
 				}
 			}


### PR DESCRIPTION
- Add logic to return the default value of an object during deserialization if it's value is not currently support (i.e. `LabelColor` of 'red_dark')
- Add HTTP information to exceptions thrown when validating a response for better diagnosing of issues